### PR TITLE
Implement LIST QUERIES that lists all running queries

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -3,7 +3,9 @@ package coordinator
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wikia/influxdb/cluster"
@@ -16,11 +18,93 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+type RunningQuery struct {
+	userName             string
+	databaseName         string
+	queryString          string
+	startTime            time.Time
+}
+
+type RunningQueryList  []*RunningQuery
+type RunningQueries struct {
+	data                 map[*RunningQuery]struct{}
+	lock                 sync.Mutex
+}
+
 type Coordinator struct {
 	clusterConfiguration *cluster.ClusterConfiguration
 	raftServer           *RaftServer
 	config               *configuration.Configuration
 	permissions          Permissions
+	runningQueries       *RunningQueries
+}
+
+func NewRunningQuery(
+	userName string, databaseName string, queryString string, startTime time.Time) *RunningQuery {
+	runningQuery := &RunningQuery{
+		userName:             userName,
+		databaseName:         databaseName,
+		queryString:          queryString,
+		startTime:            startTime,
+	}
+
+	return runningQuery
+}
+
+func NewRunningQueries() *RunningQueries {
+	runningQueries := &RunningQueries{
+		data:                 make(map[*RunningQuery]struct {}),
+	}
+
+	return runningQueries
+}
+
+func (self *RunningQueries) Add(q *RunningQuery) {
+	self.lock.Lock()
+	self.data[q] = struct{}{}
+	self.lock.Unlock()
+}
+
+func (self *RunningQueries) Remove(q *RunningQuery) {
+	self.lock.Lock()
+	delete(self.data, q)
+	self.lock.Unlock()
+}
+
+func (self *RunningQueries) All() <-chan *RunningQuery {
+	ch := make(chan *RunningQuery)
+	self.lock.Lock()
+	go func() {
+		for elem := range self.data {
+			ch <- elem
+		}
+		close(ch)
+		self.lock.Unlock()
+	}()
+
+	return ch
+}
+
+func (self *RunningQueries) AllSorted() *RunningQueryList {
+	all := RunningQueryList{}
+	for q := range self.All() {
+		all = append(all,q)
+	}
+	sort.Sort(all)
+
+	return &all
+}
+
+func (self RunningQueryList) Len() int {
+	return len(self)
+}
+
+func (self RunningQueryList) Less(i, j int) bool {
+	return (self[i]).startTime.UnixNano() > (self[j]).startTime.UnixNano()
+}
+
+func (self RunningQueryList) Swap(i, j int) {
+	self[i], self[j] = self[j], self[i]
 }
 
 func NewCoordinator(
@@ -32,6 +116,7 @@ func NewCoordinator(
 		clusterConfiguration: clusterConfiguration,
 		raftServer:           raftServer,
 		permissions:          Permissions{},
+		runningQueries:       NewRunningQueries(),
 	}
 
 	return coordinator
@@ -39,6 +124,11 @@ func NewCoordinator(
 
 func (self *Coordinator) RunQuery(user common.User, database string, queryString string, p engine.Processor) (err error) {
 	log.Info("Start Query: db: %s, u: %s, q: %s", database, user.GetName(), queryString)
+	runningQuery := NewRunningQuery(user.GetName(), database, queryString, time.Now())
+	self.runningQueries.Add(runningQuery)
+	defer func(){
+		self.runningQueries.Remove(runningQuery)
+	}()
 	defer func(t time.Time) {
 		log.Debug("End Query: db: %s, u: %s, q: %s, t: %s", database, user.GetName(), queryString, time.Now().Sub(t))
 	}(time.Now())
@@ -76,7 +166,9 @@ func (self *Coordinator) runSingleQuery(user common.User, db string, q *parser.Q
 		return self.runContinuousQuery(user, db, q.GetQueryString())
 	case parser.ListSeries:
 		return self.runListSeriesQuery(querySpec, p)
-		// Data queries
+	case parser.ListQueries:
+		return self.runListQueries(user, db, p)
+	// Data queries
 	case parser.Delete:
 		return self.runDeleteQuery(querySpec, p)
 	case parser.DropSeries:
@@ -90,6 +182,19 @@ func (self *Coordinator) runSingleQuery(user common.User, db string, q *parser.Q
 
 func (self *Coordinator) runListContinuousQueries(user common.User, db string, p engine.Processor) error {
 	queries, err := self.ListContinuousQueries(user, db)
+	if err != nil {
+		return err
+	}
+	for _, q := range queries {
+		if ok, err := p.Yield(q); !ok || err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (self *Coordinator) runListQueries(user common.User, db string, p engine.Processor) error {
+	queries, err := self.ListQueries(user, db)
 	if err != nil {
 		return err
 	}
@@ -669,6 +774,37 @@ func (self *Coordinator) ListContinuousQueries(user common.User, db string) ([]*
 	series := []*protocol.Series{{
 		Name:   &seriesName,
 		Fields: []string{"id", "query"},
+		Points: points,
+	}}
+	return series, nil
+}
+
+func (self *Coordinator) ListQueries(user common.User, db string) ([]*protocol.Series, error) {
+	if ok, err := self.permissions.AuthorizeListQueries(user, db); !ok {
+		return nil, err
+	}
+
+	points := []*protocol.Point{}
+	now := time.Now()
+
+	for _, runningQuery := range *self.runningQueries.AllSorted() {
+		userName := runningQuery.userName
+		databaseName := runningQuery.databaseName
+		queryString := runningQuery.queryString
+		timeSoFar := now.Sub(runningQuery.startTime).Seconds()
+		points = append(points, &protocol.Point{
+			Values: []*protocol.FieldValue{
+				{StringValue: &userName},
+				{StringValue: &databaseName},
+				{StringValue: &queryString},
+				{DoubleValue: &timeSoFar},
+			},
+		})
+	}
+	seriesName := "running queries"
+	series := []*protocol.Series{{
+		Name:   &seriesName,
+		Fields: []string{"user", "database", "query", "running_time"},
 		Points: points,
 	}}
 	return series, nil

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -100,7 +100,7 @@ func (self RunningQueryList) Len() int {
 }
 
 func (self RunningQueryList) Less(i, j int) bool {
-	return (self[i]).startTime.UnixNano() > (self[j]).startTime.UnixNano()
+	return (self[i]).startTime.UnixNano() < (self[j]).startTime.UnixNano()
 }
 
 func (self RunningQueryList) Swap(i, j int) {

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -28,7 +28,7 @@ type RunningQuery struct {
 type RunningQueryList  []*RunningQuery
 type RunningQueries struct {
 	data                 map[*RunningQuery]struct{}
-	lock                 sync.Mutex
+	sync.Mutex
 }
 
 type Coordinator struct {
@@ -60,26 +60,26 @@ func NewRunningQueries() *RunningQueries {
 }
 
 func (self *RunningQueries) Add(q *RunningQuery) {
-	self.lock.Lock()
+	self.Lock()
 	self.data[q] = struct{}{}
-	self.lock.Unlock()
+	self.Unlock()
 }
 
 func (self *RunningQueries) Remove(q *RunningQuery) {
-	self.lock.Lock()
+	self.Lock()
 	delete(self.data, q)
-	self.lock.Unlock()
+	self.Unlock()
 }
 
 func (self *RunningQueries) All() <-chan *RunningQuery {
 	ch := make(chan *RunningQuery)
 	go func() {
-		self.lock.Lock()
+		self.Lock()
 		for elem := range self.data {
 			ch <- elem
 		}
 		close(ch)
-		self.lock.Unlock()
+		self.Unlock()
 	}()
 
 	return ch

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -73,8 +73,8 @@ func (self *RunningQueries) Remove(q *RunningQuery) {
 
 func (self *RunningQueries) All() <-chan *RunningQuery {
 	ch := make(chan *RunningQuery)
-	self.lock.Lock()
 	go func() {
+		self.lock.Lock()
 		for elem := range self.data {
 			ch <- elem
 		}

--- a/coordinator/permissions.go
+++ b/coordinator/permissions.go
@@ -72,6 +72,14 @@ func (self *Permissions) AuthorizeListContinuousQueries(user common.User, db str
 	return true, ""
 }
 
+func (self *Permissions) AuthorizeListQueries(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to list running queries")
+	}
+
+	return true, ""
+}
+
 func (self *Permissions) AuthorizeCreateDatabase(user common.User) (ok bool, err common.AuthorizationError) {
 	if !user.IsClusterAdmin() {
 		return false, common.NewAuthorizationError("Insufficient permissions to create database")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -54,6 +54,7 @@ type ListType int
 
 const (
 	Series ListType = iota
+	Queries
 	ContinuousQueries
 	SeriesWithRegex
 )
@@ -124,6 +125,8 @@ func (self *Query) commonGetQueryString(withTime bool) string {
 		return fmt.Sprintf("drop continuous query %d", self.DropQuery.Id)
 	case ListSeries:
 		return "list series"
+	case ListQueries:
+		return "list queries"
 	case ListContinuousQueries:
 		return "list continuous queries"
 	case DropSeries:
@@ -151,6 +154,10 @@ func (self *Query) IsListSeriesQuery() bool {
 
 func (self *Query) IsListContinuousQueriesQuery() bool {
 	return self.ListQuery != nil && self.ListQuery.Type == ContinuousQueries
+}
+
+func (self *Query) IsListQueriesQuery() bool {
+	return self.ListQuery != nil && self.ListQuery.Type == Queries
 }
 
 func (self *ListQuery) HasRegex() bool {
@@ -655,6 +662,10 @@ func parseSingleQuery(q *C.query) (*Query, error) {
 
 	if q.list_continuous_queries_query != 0 {
 		return &Query{ListQuery: &ListQuery{Type: ContinuousQueries}, qType: ListContinuousQueries}, nil
+	}
+
+	if q.list_queries_query != 0 {
+		return &Query{ListQuery: &ListQuery{Type: Queries}, qType: ListQueries}, nil
 	}
 
 	if q.select_query != nil {

--- a/parser/query.lex
+++ b/parser/query.lex
@@ -32,6 +32,7 @@ static int yycolumn = 1;
 "merge"                   { return MERGE; }
 "list"                    { return LIST; }
 "series"                  { BEGIN(LIST_SERIES); return SERIES; }
+"queries"                 { return QUERIES; }
 "continuous query"        { return CONTINUOUS_QUERY; }
 "continuous queries"      { return CONTINUOUS_QUERIES; }
 "inner"                   { return INNER; }

--- a/parser/query.yacc
+++ b/parser/query.yacc
@@ -75,7 +75,7 @@ value *create_expression_value(char *operator, size_t size, ...) {
 %lex-param   {void *scanner}
 
 // define types of tokens (terminals)
-%token          SELECT DELETE FROM WHERE EQUAL GROUP BY LIMIT ORDER ASC DESC MERGE INNER JOIN AS LIST SERIES INTO CONTINUOUS_QUERIES CONTINUOUS_QUERY DROP DROP_SERIES EXPLAIN UNKNOWN INCLUDE SPACES
+%token          SELECT DELETE FROM WHERE EQUAL GROUP BY LIMIT ORDER ASC DESC MERGE INNER JOIN AS LIST SERIES QUERIES INTO CONTINUOUS_QUERIES CONTINUOUS_QUERY DROP DROP_SERIES EXPLAIN UNKNOWN INCLUDE SPACES
 %token <string> STRING_VALUE INT_VALUE FLOAT_VALUE BOOLEAN_VALUE TABLE_NAME SIMPLE_NAME INTO_NAME REGEX_OP
 %token <string>  NEGATION_REGEX_OP REGEX_STRING INSENSITIVE_REGEX_STRING DURATION
 
@@ -160,6 +160,12 @@ QUERY:
         {
           $$ = calloc(1, sizeof(query));
           $$->drop_query = $1;
+        }
+        |
+        LIST QUERIES
+        {
+          $$ = calloc(1, sizeof(query));
+          $$->list_queries_query = TRUE;
         }
         |
         LIST SERIES INCLUDE SPACES

--- a/parser/query_type.go
+++ b/parser/query_type.go
@@ -9,6 +9,7 @@ const (
 	Delete
 	DropContinuousQuery
 	ListSeries
+	ListQueries
 	ListContinuousQueries
 	DropSeries
 	Continuous
@@ -24,6 +25,8 @@ func (qt QueryType) String() string {
 		return "drop continuous query"
 	case ListSeries:
 		return "list series"
+	case ListQueries:
+		return "list queries"
 	case ListContinuousQueries:
 		return "list continuous queries"
 	case DropSeries:

--- a/parser/query_types.h
+++ b/parser/query_types.h
@@ -125,6 +125,7 @@ typedef struct {
   drop_query *drop_query;
   list_series_query *list_series_query;
   char list_continuous_queries_query;
+  char list_queries_query;
 } query;
 
 // queries is an array of query


### PR DESCRIPTION
Since now we've had a painful lack of visibility into what's going on under the hood of influxdb.

I'm now adding LIST QUERIES that lists all running queries along with the time they're already being executed. Hopefully this will help us in a few cases.

Note: this is already live on our servers so you can give it a try..

/cc @macbre @jcellary @owend @drsnyder @ArturKlajnerok 
